### PR TITLE
Update Hosts List

### DIFF
--- a/spotyblock.sh
+++ b/spotyblock.sh
@@ -19,7 +19,6 @@ HOSTS="#[Spotify Ad-Block Hosts]
 0.0.0.0 omaze.com
 0.0.0.0 redirector.gvt1.com
 0.0.0.0 s0.2mdn.net
-0.0.0.0 spclient.wg.spotify.com
 0.0.0.0 v.jwpcdn.com
 0.0.0.0 weblb-wg.gslb.spotify.com
 0.0.0.0 www.omaze.com"
@@ -41,7 +40,7 @@ clear
 
 if grep -q "Spotify Ad-Block Hosts" /private/etc/hosts;
 then
-	printf "You have already runned this script\n"
+	printf "You have already ran this script\n"
     read -p "  Press enter to exit"
 	clear && exit
 fi


### PR DESCRIPTION
Updated hosts list by removing the host "spclient.wg.spotify.com". If it is left in, Spotify cannot stream music properly and will not work. By removing this host, (some) banner ads will not be blocked, but from my experience, audio ads are still completely blocked.